### PR TITLE
Update line-continuation character for 'Publish extension' pwsh script

### DIFF
--- a/.azure-pipelines/templates/stages/publish-extension.yml
+++ b/.azure-pipelines/templates/stages/publish-extension.yml
@@ -64,8 +64,8 @@ stages:
               scriptType: pscore
               scriptLocation: inlineScript
               inlineScript: |
-                npx @vscode/vsce@latest publish \
-                  -i $(Pipeline.Workspace)/vsix-artifacts/$(VSIX_FILE_NAME) \
-                  --manifestPath $(Pipeline.Workspace)/vsix-artifacts/extension.manifest \
-                  --signaturePath $(Pipeline.Workspace)/vsix-artifacts/extension.signature.p7s \
+                npx @vscode/vsce@latest publish `
+                  -i $(Pipeline.Workspace)/vsix-artifacts/$(VSIX_FILE_NAME) `
+                  --manifestPath $(Pipeline.Workspace)/vsix-artifacts/extension.manifest `
+                  --signaturePath $(Pipeline.Workspace)/vsix-artifacts/extension.signature.p7s `
                   --azure-credential


### PR DESCRIPTION
The script to publish the extension to the marketplace had been using bash-style line continuation (\) in a PowerShell script. PowerShell uses backticks (`) for line continuation, not backslashes.