### PR TITLE
Remove enable API proposals entry

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -13,9 +13,6 @@
   "engines": {
     "vscode": "^1.77.0"
   },
-  "enabledApiProposals": [
-    "telemetry"
-  ],
   "categories": [
     "Data Science"
   ],


### PR DESCRIPTION
Publishing the extension to the marketplace is failing:

> "ERROR  Extensions using unallowed proposed API (enabledApiProposals: [telemetry], allowed: []) can't be published to the Marketplace. Use --allow-proposed-apis <APIS...> or --allow-all-proposed-apis to bypass."

This proposed API was enabled by a GitHub copilot change with the comment:

> "Fix failing tests and enable NuGet Central Package Management"

No mention as to what tests were failing or what this entry had to do with enabling NuGet CPM (spoiler alert: it had nothing to do with nuget).

The API that was enabled revolves around `TelemetryConfiguration` (see this [vscode commit](https://github.com/microsoft/vscode/pull/141086)) which is unused in the vscode-fabric codebase.