### PR TITLE
Include 'Create item' on an artifact type node

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -381,7 +381,17 @@
         },
         {
           "command": "vscode-fabric.createArtifact",
+          "when": "view == vscode-fabric.view.workspace && viewItem == ItemType",
+          "group": "1@1"
+        },
+        {
+          "command": "vscode-fabric.createArtifact",
           "when": "view == vscode-fabric.view.workspace && viewItem == WorkspaceTreeNode",
+          "group": "inline"
+        },
+        {
+          "command": "vscode-fabric.createArtifact",
+          "when": "view == vscode-fabric.view.workspace && viewItem == ItemType",
           "group": "inline"
         },
         {

--- a/extension/src/artifactManager/commands.ts
+++ b/extension/src/artifactManager/commands.ts
@@ -27,6 +27,7 @@ import { showSignInPrompt } from '../ui/prompts';
 import { ICapacityManager } from '../CapacityManager';
 import { showWorkspaceQuickPick } from '../ui/showWorkspaceQuickPick';
 import { WorkspaceTreeNode } from '../workspace/treeNodes/WorkspaceTreeNode';
+import { ArtifactTypeTreeNode } from '../workspace/treeNodes/ArtifactTypeTreeNode';
 import { ItemDefinitionConflictDetector } from '../itemDefinition/ItemDefinitionConflictDetector';
 import { IWorkspaceFilterManager } from '../workspace/WorkspaceFilterManager';
 import { ILocalFolderService } from '../LocalFolderService';
@@ -69,13 +70,22 @@ export async function registerArtifactCommands(context: vscode.ExtensionContext,
                 return;
             }
 
-            // Check if called from workspace context menu
-            const workspaceTreeNode = cmdArgs[0] as WorkspaceTreeNode | undefined;
-            const preselectedWorkspaceId = workspaceTreeNode?.workspace.objectId;
+            // Check if called from workspace or artifact type context menu
+            let preselectedWorkspaceId: string | undefined;
+            let preselectedArtifactType: string | undefined;
+
+            const contextNode = cmdArgs[0];
+            if (contextNode instanceof WorkspaceTreeNode) {
+                preselectedWorkspaceId = contextNode.workspace.objectId;
+            }
+            else if (contextNode instanceof ArtifactTypeTreeNode) {
+                preselectedWorkspaceId = contextNode.workspaceId;
+                preselectedArtifactType = contextNode.artifactType;
+            }
 
             const promptResult: { type: string, name: string, workspaceId: string } | undefined = await promptForArtifactTypeAndName(
                 context,
-                new CreateItemsProvider(fabricItemMetadata),
+                new CreateItemsProvider(fabricItemMetadata, preselectedArtifactType),
                 workspaceManager,
                 capacityManager,
                 workspaceFilterManager,

--- a/extension/src/artifactManager/createArtifactCommand.ts
+++ b/extension/src/artifactManager/createArtifactCommand.ts
@@ -76,10 +76,19 @@ export async function promptForArtifactTypeAndName(
     creatableItems.sort((a, b) => a.displayName.localeCompare(b.displayName));
     creatableItems.forEach(details => quickPickTypeItems.push(new CreateItemTypeQuickPickItem(details)));
 
-    const selectedArtifactType = await vscode.window.showQuickPick(
-        quickPickTypeItems,
-        { title: vscode.l10n.t('Choose Item type...'), canPickMany: false }
-    );
+    let selectedArtifactType: CreateItemTypeQuickPickItem | undefined;
+
+    if (quickPickTypeItems.length === 1) {
+        // If only one type is available, skip the picker and use it directly
+        selectedArtifactType = quickPickTypeItems[0];
+    }
+    else {
+        // Show the artifact type picker
+        selectedArtifactType = await vscode.window.showQuickPick(
+            quickPickTypeItems,
+            { title: vscode.l10n.t('Choose Item type...'), canPickMany: false }
+        );
+    }
 
     if (!selectedArtifactType) {
         return undefined;

--- a/extension/src/metadata/CreateItemsProvider.ts
+++ b/extension/src/metadata/CreateItemsProvider.ts
@@ -6,21 +6,39 @@ import { ICreateItemsProvider, ItemCreationDetails, CreationCapability, FabricIt
 import { getArtifactDefaultIconPath, getArtifactIconPath } from './fabricItemUtilities';
 
 export class CreateItemsProvider implements ICreateItemsProvider {
-    public constructor(private readonly fabricItemMetadata: Partial<Record<string, FabricItemMetadata>>) {}
+    public constructor(
+        private readonly fabricItemMetadata: Partial<Record<string, FabricItemMetadata>>,
+        private readonly artifactTypeFilter?: string
+    ) {}
 
     public getItemsForCreate(baseUri: vscode.Uri): ItemCreationDetails[] {
         const items: ItemCreationDetails[] = [];
-        for (const [key, value] of Object.entries(this.fabricItemMetadata)) {
-            if (value?.creationCapability !== undefined && value.creationCapability !== CreationCapability.unsupported) {
-                items.push({
-                    type: key,
-                    displayName: value.displayName ?? key,
-                    description: value.creationDescription ?? vscode.l10n.t('Create a new {0}', value.displayName ?? key),
-                    creationCapability: value.creationCapability,
-                    iconPath: value.iconInformation ? getArtifactIconPath(baseUri, key) : getArtifactDefaultIconPath(baseUri),
-                });
+
+        // If a filter is provided and exists in metadata, return only that type
+        if (this.artifactTypeFilter && this.fabricItemMetadata[this.artifactTypeFilter]) {
+            if (this.addItemIfCreatable(this.artifactTypeFilter, this.fabricItemMetadata[this.artifactTypeFilter], baseUri, items)) {
+                return items;
             }
         }
+
+        // Otherwise, return all creatable items
+        for (const [key, value] of Object.entries(this.fabricItemMetadata)) {
+            this.addItemIfCreatable(key, value, baseUri, items);
+        }
         return items;
+    }
+
+    private addItemIfCreatable(type: string, metadata: FabricItemMetadata | undefined, baseUri: vscode.Uri, items: ItemCreationDetails[]): boolean {
+        if (metadata?.creationCapability !== undefined && metadata.creationCapability !== CreationCapability.unsupported) {
+            items.push({
+                type: type,
+                displayName: metadata.displayName ?? type,
+                description: metadata.creationDescription ?? vscode.l10n.t('Create a new {0}', metadata.displayName ?? type),
+                creationCapability: metadata.creationCapability,
+                iconPath: metadata.iconInformation ? getArtifactIconPath(baseUri, type) : getArtifactDefaultIconPath(baseUri),
+            });
+            return true;
+        }
+        return false;
     }
 }

--- a/extension/src/workspace/treeNodes/ArtifactTypeTreeNode.ts
+++ b/extension/src/workspace/treeNodes/ArtifactTypeTreeNode.ts
@@ -20,7 +20,7 @@ export class ArtifactTypeTreeNode extends FabricTreeNode {
         context: vscode.ExtensionContext,
         protected extensionManager: IFabricExtensionManagerInternal,
         public artifactType: string,
-        private workspaceId: string,
+        public readonly workspaceId: string,
         private tenantId: string | undefined,
         private localFolderService: ILocalFolderService,
         private shouldExpand?: (id: string | undefined) => boolean


### PR DESCRIPTION
Adds the Create Item command to the artifact type node. 

When invoked, the artifact type of the node is used, eliminating one of the questions typically asked by the Create Item command