### PR TITLE
Update the portalFolder for semantic model

### DIFF
--- a/extension/src/metadata/fabricItemMetadata.ts
+++ b/extension/src/metadata/fabricItemMetadata.ts
@@ -202,7 +202,7 @@ export const fabricItemMetadata: Partial<Record<string, FabricItemMetadata>> = {
         displayName: vscode.l10n.t('Semantic model'),
         displayNamePlural: vscode.l10n.t('Semantic models'),
         iconInformation: { fileName: 'semantic_model_32.svg', isThemed: true },
-        portalFolder: 'semanticmodels',
+        portalFolder: 'datasets',
         supportsArtifactWithDefinition: true,
         extensionId: 'analysis-services.TMDL',
     },


### PR DESCRIPTION
Navigating to a semantic model ("Open in Fabric") was giving a 404 because the item because the open was going to 'semanticmodels' (msit.powerbi.com/groups/3a0749f1-8406-4939-903b-046b17e2b890/**semanticmodels**/ba0a66bb-6039-44c2-a4ec-691343e4fb50?experience=fabric-developer) instead of 'datasets' (msit.powerbi.com/groups/3a0749f1-8406-4939-903b-046b17e2b890/**datasets**/ba0a66bb-6039-44c2-a4ec-691343e4fb50?experience=fabric-developer). First raised in issue https://github.com/microsoft/vscode-fabric/issues/64

I re-checked other well-known items and all of them worked as is.