### PR TITLE
Show folders by default

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -562,9 +562,8 @@
             },
             "Fabric.ShowFolders": {
                 "type": "boolean",
-                "default": false,
-                "description": "%extension.configuration.ShowFolders.description%",
-                "tags": [ "preview" ]
+                "default": true,
+                "description": "%extension.configuration.ShowFolders.description%"
             },
             "Fabric.McpServer.PromptInstall": {
                 "type": "boolean",


### PR DESCRIPTION
Turn off 'preview' flag for show folders; make showing folders the default