### PR TITLE
Prepare for 0.38 release

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/vscode-fabric-api",
   "author": "Microsoft Corporation",
-  "version": "0.37.0-preview",
+  "version": "0.38.0-preview",
   "displayName": "Microsoft Fabric - APIs for VS Code",
   "description": "Contains APIs for interacting with Microsoft Fabric and VS Code Fabric extensions",
   "tags": [

--- a/api/version.json
+++ b/api/version.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-	"version": "0.37",
+	"version": "0.38",
   "pathFilters": ["."],
 	"publicReleaseRefSpec": [
 		"^refs/heads/main$",

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,9 +1,19 @@
 # Change Log
 
-## [0.37 (Pre-release)] 2026-01
+## [0.38] 2026-02-19
 
 ### Added
-- "Install extension" breadcrumb in local projects view 
+- "Install extension" breadcrumb in local projects view.
+- Prompt to install Fabric MCP server extension when GitHub Copilot Chat is detected, offering enhanced Fabric-aware Copilot functionality.
+- Item definition files are now viewable directly in the remote workspace tree view: each item exposes an "Item definition" node listing its definition files as read-only previews.
+- Item definition files can be directly edited via a virtual file system; saving automatically updates the item definition via the Fabric API. This feature is behind a Preview setting and is off by default.
+- Fabric agent mode added with Copilot instructions for assisting users with and without the Fabric MCP server installed.
+
+### Changed
+- Local folder view now shows folders by default (no longer requires enabling a Preview setting).
+
+### Fixed
+- Fixed "Open in Fabric" navigation for Semantic Models, which was returning a 404 due to an incorrect portal path (`semanticmodels` → `datasets`).
 
 ## [0.36] 2026-01-06
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -3,7 +3,7 @@
   "publisher": "fabric",
   "displayName": "Microsoft Fabric",
   "description": "View, manage, and develop your Microsoft Fabric items directly in VS Code.",
-  "version": "0.37.0-placeholder",
+  "version": "0.38.0-placeholder",
   "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
   "icon": "resources/fabric.png",
   "repository": "https://github.com/microsoft/microsoft-fabric-vscode-extension/",
@@ -637,7 +637,7 @@
     "lint:check": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\" --fix",
     "bundle": "webpack --mode production --devtool hidden-source-map",
-    "vsix": "npm run bundle && vsce package --allow-missing-repository --pre-release --no-dependencies --baseImagesUrl https://raw.githubusercontent.com/microsoft/microsoft-fabric-vscode-extension/main/",
+    "vsix": "npm run bundle && vsce package --allow-missing-repository --no-dependencies --baseImagesUrl https://raw.githubusercontent.com/microsoft/microsoft-fabric-vscode-extension/main/",
     "clean": "npm exec rimraf dist out .test-extensions",
     "clean:all": "npm run clean && npm exec rimraf node_modules",
     "localization": "npx @vscode/l10n-dev export -o ./l10n ./src"
@@ -645,8 +645,8 @@
   "dependencies": {
     "@azure/core-rest-pipeline": "^1.14.0",
     "@microsoft/vscode-azext-azureauth": "~4.1.1",
-    "@microsoft/vscode-fabric-api": "^0.37.0-preview",
-    "@microsoft/vscode-fabric-util": "^0.37.0-preview",
+    "@microsoft/vscode-fabric-api": "^0.38.0-preview",
+    "@microsoft/vscode-fabric-util": "^0.38.0-preview",
     "@types/fs-extra": "^11.0.1",
     "@vscode/extension-telemetry": "^0.8.3",
     "fs-extra": "^11.1.1",

--- a/extension/version.json
+++ b/extension/version.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-	"version": "0.37",
+	"version": "0.38",
 	"pathFilters": [".", "../util", "../api"],
 	"publicReleaseRefSpec": [
 		"^refs/heads/main$",

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
     },
     "api": {
       "name": "@microsoft/vscode-fabric-api",
-      "version": "0.37.0-preview",
+      "version": "0.38.0-preview",
       "license": "MIT",
       "dependencies": {
         "@azure/core-rest-pipeline": "^1.14.0",
@@ -67,13 +67,13 @@
     },
     "extension": {
       "name": "vscode-fabric",
-      "version": "0.37.0-placeholder",
+      "version": "0.38.0-placeholder",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@azure/core-rest-pipeline": "^1.14.0",
         "@microsoft/vscode-azext-azureauth": "~4.1.1",
-        "@microsoft/vscode-fabric-api": "^0.37.0-preview",
-        "@microsoft/vscode-fabric-util": "^0.37.0-preview",
+        "@microsoft/vscode-fabric-api": "^0.38.0-preview",
+        "@microsoft/vscode-fabric-util": "^0.38.0-preview",
         "@types/fs-extra": "^11.0.1",
         "@vscode/extension-telemetry": "^0.8.3",
         "fs-extra": "^11.1.1",
@@ -12179,12 +12179,12 @@
     },
     "util": {
       "name": "@microsoft/vscode-fabric-util",
-      "version": "0.37.0-preview",
+      "version": "0.38.0-preview",
       "license": "MIT",
       "dependencies": {
         "@azure/arm-resources-subscriptions": "^2.1.0",
         "@azure/core-rest-pipeline": "^1.14.0",
-        "@microsoft/vscode-fabric-api": "^0.37.0-preview",
+        "@microsoft/vscode-fabric-api": "^0.38.0-preview",
         "@vscode/extension-telemetry": "^0.9.0",
         "decompress": "^4.2.1"
       },

--- a/util/package.json
+++ b/util/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/vscode-fabric-util",
   "author": "Microsoft Corporation",
-  "version": "0.37.0-preview",
+  "version": "0.38.0-preview",
   "displayName": "Microsoft Fabric - Utilities for VS Code",
   "description": "Contains utilities for interacting with Microsoft Fabric and VS Code Fabric extensions",
   "tags": [
@@ -38,7 +38,7 @@
   "dependencies": {
     "@azure/arm-resources-subscriptions": "^2.1.0",
     "@azure/core-rest-pipeline": "^1.14.0",
-    "@microsoft/vscode-fabric-api": "^0.37.0-preview",
+    "@microsoft/vscode-fabric-api": "^0.38.0-preview",
     "@vscode/extension-telemetry": "^0.9.0",
     "decompress": "^4.2.1"
   },

--- a/util/version.json
+++ b/util/version.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-	"version": "0.37",
+	"version": "0.38",
   "pathFilters": ["."],
 	"publicReleaseRefSpec": [
 		"^refs/heads/main$",


### PR DESCRIPTION
- Bumps version numbers to 0.38
- Remove --pre-release tag from extension
- Updates CHANGELOG.md