### PR TITLE
Add metadata indicating Lakehouse, MLExperiment and MLModel support item definition

### DIFF
--- a/extension/src/metadata/fabricItemMetadata.ts
+++ b/extension/src/metadata/fabricItemMetadata.ts
@@ -125,6 +125,7 @@ export const fabricItemMetadata: Partial<Record<string, FabricItemMetadata>> = {
         displayNamePlural: vscode.l10n.t('Experiments'),
         iconInformation: { fileName: 'experiments_24.svg', isThemed: true },
         portalFolder: 'mlexperiments',
+        supportsArtifactWithDefinition: true,
     },
     'MLModel': {
         creationCapability: CreationCapability.supported,
@@ -133,6 +134,7 @@ export const fabricItemMetadata: Partial<Record<string, FabricItemMetadata>> = {
         displayNamePlural: vscode.l10n.t('ML models'),
         iconInformation: { fileName: 'model_24.svg', isThemed: true },
         portalFolder: 'mlmodels',
+        supportsArtifactWithDefinition: true,
     },
     'MirroredDatabase': {
         creationCapability: CreationCapability.unsupported,

--- a/extension/src/metadata/fabricItemMetadata.ts
+++ b/extension/src/metadata/fabricItemMetadata.ts
@@ -116,6 +116,7 @@ export const fabricItemMetadata: Partial<Record<string, FabricItemMetadata>> = {
         displayNamePlural: vscode.l10n.t('Lakehouses'),
         iconInformation: { fileName: 'lakehouse_24.svg', isThemed: true },
         portalFolder: 'lakehouses',
+        supportsArtifactWithDefinition: true,
     },
     'MLExperiment': {
         creationCapability: CreationCapability.supported,


### PR DESCRIPTION
Fix for #98 