### PR TITLE
fix: prevent UTF-8 corruption of binary image payloads during workspace sync

### DIFF
--- a/extension/src/workspace/treeNodes/childNodeProviders/DefinitionFilesChildNodeProvider.ts
+++ b/extension/src/workspace/treeNodes/childNodeProviders/DefinitionFilesChildNodeProvider.ts
@@ -83,9 +83,13 @@ export class DefinitionFilesChildNodeProvider implements IArtifactChildNodeProvi
                 // Decode base64 content
                 content = base64ToUint8Array(part.payload);
             }
+            else if (part.path.match(/\.(png|jpg|jpeg|gif|ico|bmp|webp|tiff)$/i)) {
+                // [HOTFIX] Bypass UTF-8 TextEncoder corruption for binaries erroneously sent as Utf8
+                content = Uint8Array.from(part.payload || '', c => c.charCodeAt(0));
+            }
             else {
                 // For other payload types, convert to bytes
-                content = stringToUint8Array(part.payload);
+                content = stringToUint8Array(part.payload || '');
             }
 
             // Register the file in the file system provider and get the editable URI

--- a/extension/test/unit/workspace/DefinitionFilesChildNodeProvider.unit.test.ts
+++ b/extension/test/unit/workspace/DefinitionFilesChildNodeProvider.unit.test.ts
@@ -400,5 +400,40 @@ describe('DefinitionFilesChildNodeProvider', function () {
             assert.ok(fileNode.readonlyUri);
             assert.strictEqual(fileNode.readonlyUri.scheme, 'fabric-definition-virtual');
         });
+
+        it('should correctly bypass stringToUint8Array for .png files disguised as Utf8 payloadType', async function () {
+            const fileName = 'image.png';
+            // Mock a corrupted binary string payload where bytes are mapped 1-to-1 to characters
+            const binaryString = '\x89PNG\r\n\x1a\n';
+            const editableUri = vscode.Uri.parse(`fabric-definition:///${workspaceId}/${artifactId}/${fileName}`);
+
+            const definition: IItemDefinition = {
+                parts: [
+                    { path: fileName, payload: binaryString, payloadType: 'Utf8' as any },
+                ],
+            };
+
+            const responseMock = new Mock<IApiClientResponse>();
+            responseMock.setup(x => x.parsedBody).returns({ definition });
+
+            artifactManagerMock.setup(x => x.getArtifactDefinition(artifact))
+                .returns(Promise.resolve(responseMock.object()));
+
+            fileSystemProviderMock.setup(x => x.registerFile(
+                artifact,
+                fileName,
+                It.Is<Uint8Array>(content => {
+                    // Check if content byte exactly matches the char code, not inflated by TextEncoder
+                    return content.length === binaryString.length && content[0] === 0x89 && content[1] === 0x50; // 0x50 is 'P'
+                })
+            )).returns(editableUri);
+
+            await provider.getChildNodes(artifact);
+
+            fileSystemProviderMock.verify(
+                x => x.registerFile(artifact, fileName, It.IsAny()),
+                Times.Once()
+            );
+        });
     });
 });


### PR DESCRIPTION
# Github Issue Submission Template

**Title:** [Bug] Binary file (.png/.jpg) corruption due to `TextEncoder` UTF-8 inflation in `DefinitionFilesChildNodeProvider`

## Description
When downloading a Fabric item (such as a Power BI Report with `StaticResources/RegisteredResources/*.png` images) from the workspace using the extension ("Download from Workspace"), binary files like images are frequently corrupted. 

The original file size inflates, and the file becomes unreadable. This occurs because the Fabric API backend sometimes serializes binary payloads loosely (with `payloadType: PayloadType.Utf8` instead of `InlineBase64`). When this happens, `DefinitionFilesChildNodeProvider.ts` applies `stringToUint8Array()` (which relies on `TextEncoder().encode()`). `TextEncoder` treats the raw binary byte values as Unicode characters and inflates any byte `> 127` (like `0x89` in PNGs) into a 2-byte or 3-byte UTF-8 sequence, completely destroying the binary format.

## Steps to Reproduce
1. Upload a Power BI Report (`.pbip`) containing custom images to a Fabric workspace.
2. Ensure the image is synchronized to the workspace.
3. In VS Code, navigate to the Fabric extension and click **Download from Workspace**.
4. Open the downloaded `StaticResources/RegisteredResources/image.png`.
5. Observe that the file is corrupted. Opening in a hex editor reveals that single bytes (e.g. `0x89`) have been bloated into UTF-8 sequence (`0xC2 0x89`), increasing file size and destroying the headers.

## Expected Behavior
Binary strings transmitted as 1-to-1 character maps should be correctly serialized back to binary bytes without Unicode inflation.

## Root Cause & Suggested Fix
**File:** `extension/src/workspace/treeNodes/childNodeProviders/DefinitionFilesChildNodeProvider.ts`
**Function:** `buildTreeStructure`

Currently, the extension assumes anything not marked explicitly as Base64 is text:
```typescript
if (part.payloadType === PayloadType.InlineBase64) {
    content = base64ToUint8Array(part.payload);
}
else {
    // BUG: Corrupts raw binary strings by encoding them to UTF-8
    content = stringToUint8Array(part.payload); 
}
```

**Proposed Fix:**
Identify typical binary file extensions or inspect the raw string stream, and bypass `TextEncoder` by using a simple byte extraction mapping:
```typescript
if (part.payloadType === PayloadType.InlineBase64) {
    content = base64ToUint8Array(part.payload);
}
else if (part.path.match(/\.(png|jpg|jpeg|gif|ico|bmp|webp|tiff)$/i)) {
    // Safely extract the 1-to-1 mapped character bytes
    content = Uint8Array.from(part.payload || '', c => c.charCodeAt(0));
}
else {
    content = stringToUint8Array(part.payload || '');
}
```

## Additional Note for Maintainers
While the proposed workaround uses a regex to target image file extensions, please note that **any other binary files included in a Fabric Item definition (such as `.ttf`, `.woff` custom fonts or `.pdf` documents)** would mathematically suffer from the exact same `TextEncoder` inflation and corruption if the backend continues to transmit them as `PayloadType.Utf8`. 

We highly recommend reviewing whether the Fabric API can natively tag all binary definition assets as `InlineBase64`, which would structurally resolve this issue for all current and future binary file types.
