### PR TITLE
fix: prevent call stack overflow in uint8ArrayToBase64 for large files

### DIFF
--- a/extension/src/bufferUtilities.ts
+++ b/extension/src/bufferUtilities.ts
@@ -11,7 +11,15 @@
  * Web-compatible replacement for: `Buffer.from(content).toString('base64')`
  */
 export function uint8ArrayToBase64(bytes: Uint8Array): string {
-    return btoa(String.fromCharCode(...bytes));
+    // Process in chunks to avoid "Maximum call stack size exceeded" when
+    // spreading large Uint8Arrays (>~65 KB) into String.fromCharCode().
+    const CHUNK_SIZE = 0x2000; // 8 KB
+    let binary = '';
+    for (let i = 0; i < bytes.length; i += CHUNK_SIZE) {
+        const chunk = bytes.subarray(i, i + CHUNK_SIZE);
+        binary += String.fromCharCode(...chunk);
+    }
+    return btoa(binary);
 }
 
 /**

--- a/extension/test/unit/general/bufferUtilities.unit.test.ts
+++ b/extension/test/unit/general/bufferUtilities.unit.test.ts
@@ -30,6 +30,29 @@ describe('bufferUtilities', () => {
             const result = uint8ArrayToBase64(bytes);
             assert.strictEqual(result, 'AAH/gEA=');
         });
+
+        it('should handle large payloads without call stack overflow (regression: >65KB files)', () => {
+            // Simulates a ~270KB binary file (e.g., a PNG image).
+            // The original spread-based implementation would throw
+            // "Maximum call stack size exceeded" at this size.
+            const size = 270_000;
+            const bytes = new Uint8Array(size);
+            for (let i = 0; i < size; i++) {
+                bytes[i] = i % 256;
+            }
+
+            // Should not throw
+            const base64 = uint8ArrayToBase64(bytes);
+
+            // Verify roundtrip integrity
+            const decoded = base64ToUint8Array(base64);
+            assert.strictEqual(decoded.length, size);
+            assert.deepStrictEqual(Array.from(decoded.slice(0, 5)), [0, 1, 2, 3, 4]);
+            assert.deepStrictEqual(
+                Array.from(decoded.slice(size - 3)),
+                [(size - 3) % 256, (size - 2) % 256, (size - 1) % 256]
+            );
+        });
     });
 
     describe('base64ToUint8Array', () => {


### PR DESCRIPTION
# Github Issue Submission Template

**Title:** [Bug] `uint8ArrayToBase64` throws "Maximum call stack size exceeded" for binary files > ~65 KB during Upload to Workspace

## Description
After applying the fix for **#135** (binary image corruption during Download from Workspace), image files are now correctly preserved at their original size. However, this exposed a latent bug in `uint8ArrayToBase64()`: when re-uploading the report back to the workspace, any correctly-downloaded binary file larger than ~65 KB triggers `Maximum call stack size exceeded`.

Previously, this went unnoticed because #135's corruption silently truncated or mangled image payloads, keeping them under the call stack argument threshold. With images now arriving intact at their true size (e.g., 269 KB), the spread operator overflow in `uint8ArrayToBase64()` is consistently triggered.

## Steps to Reproduce
1. Apply the fix from **#135** to correctly handle binary image downloads.
2. **Download from Workspace** a Power BI report containing registered resource images ≥ 65 KB — images are now correctly retrieved at their original size.
3. **Upload to Workspace** the same report back to Fabric.
4. Observe the error:
   ```
   Error processing file 'StaticResources/RegisteredResources/____21341551403261538.png': Maximum call stack size exceeded
   ```

## Expected Behavior
Binary files of any size should be successfully encoded to base64 and uploaded to the workspace without errors.

## Root Cause & Suggested Fix
**File:** `extension/src/bufferUtilities.ts`
**Function:** `uint8ArrayToBase64`

Currently, the function uses the spread operator to pass every byte as a separate function argument:
```typescript
export function uint8ArrayToBase64(bytes: Uint8Array): string {
    return btoa(String.fromCharCode(...bytes));
}
```

JavaScript engines impose limits on the number of function arguments (V8: ~65,536, SpiderMonkey: ~500,000). A 269 KB PNG file produces ~269,000 arguments, far exceeding V8's limit and causing the call stack overflow.

**Proposed Fix:**
Process the `Uint8Array` in 8 KB chunks to stay well within all JS engine limits:
```typescript
export function uint8ArrayToBase64(bytes: Uint8Array): string {
    const CHUNK_SIZE = 0x2000; // 8 KB
    let binary = '';
    for (let i = 0; i < bytes.length; i += CHUNK_SIZE) {
        const chunk = bytes.subarray(i, i + CHUNK_SIZE);
        binary += String.fromCharCode(...chunk);
    }
    return btoa(binary);
}
```

## Additional Note for Maintainers
This bug affects **all binary file types** processed through `uint8ArrayToBase64()` during the Upload to Workspace flow — not just images. Any definition asset (e.g., `.ttf`, `.woff` custom fonts, `.pdf` documents) exceeding ~65 KB would trigger the same overflow. The chunked approach resolves this universally for all current and future file types regardless of size.

A regression test with a 270 KB payload is included in the fix branch to prevent reintroduction.
